### PR TITLE
Changing default zone value to NULL.

### DIFF
--- a/src/Audit/AccountMembersAnalysis.php
+++ b/src/Audit/AccountMembersAnalysis.php
@@ -25,7 +25,7 @@ class AccountMembersAnalysis extends AbstractAnalysis
             'zone',
             static::PARAMETER_OPTIONAL,
             'The apex domain registered with Cloudflare.',
-            ''
+            NULL
         );
         $this->addParameter(
             'expression',

--- a/src/Audit/DNSAnalysis.php
+++ b/src/Audit/DNSAnalysis.php
@@ -25,7 +25,7 @@ class DNSAnalysis extends AbstractAnalysis
             'zone',
             static::PARAMETER_OPTIONAL,
             'The apex domain registered with Cloudflare.',
-            ''
+            NULL
         );
         $this->addParameter(
             'expression',

--- a/src/Audit/FirewallAccessRulesAnalysis.php
+++ b/src/Audit/FirewallAccessRulesAnalysis.php
@@ -25,7 +25,7 @@ class FirewallAccessRulesAnalysis extends AbstractAnalysis
             'zone',
             static::PARAMETER_OPTIONAL,
             'The apex domain registered with Cloudflare.',
-            ''
+            NULL
         );
         $this->addParameter(
             'expression',

--- a/src/Audit/FirewallRulesAnalysis.php
+++ b/src/Audit/FirewallRulesAnalysis.php
@@ -25,7 +25,7 @@ class FirewallRulesAnalysis extends AbstractAnalysis
             'zone',
             static::PARAMETER_OPTIONAL,
             'The apex domain registered with Cloudflare.',
-            ''
+            NULL
         );
         $this->addParameter(
             'expression',

--- a/src/Audit/PageRuleAnalysis.php
+++ b/src/Audit/PageRuleAnalysis.php
@@ -25,7 +25,7 @@ class PageRuleAnalysis extends AbstractAnalysis
             'zone',
             static::PARAMETER_OPTIONAL,
             'The apex domain registered with Cloudflare.',
-            ''
+            NULL
         );
         $this->addParameter(
             'rule',

--- a/src/Audit/PageRuleMatch.php
+++ b/src/Audit/PageRuleMatch.php
@@ -32,7 +32,7 @@ class PageRuleMatch extends ApiEnabledAudit {
         'zone',
         static::PARAMETER_OPTIONAL,
         'The apex domain registered with Cloudflare.',
-        ''
+        NULL
       );
       $this->addParameter(
         'rule',

--- a/src/Audit/PageRulesAnalysis.php
+++ b/src/Audit/PageRulesAnalysis.php
@@ -25,7 +25,7 @@ class PageRulesAnalysis extends AbstractAnalysis
             'zone',
             static::PARAMETER_OPTIONAL,
             'The apex domain registered with Cloudflare.',
-            ''
+            NULL
         );
         $this->addParameter(
             'expression',


### PR DESCRIPTION
The previous default value was blank ''. This resulted in the zone evaluating to blank rather than parsing the zone from the --uri parameter. 